### PR TITLE
feat(#15): Allow receiving callbacks when a client connects/disconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ ok
 <<"example;my-message">>
 ```
 
+## Subscription publications
+
+When a client connects to the `/websocket` or `/eventsource` endpoints, a special message will be published to the topic `nrte:subscription_init:{{source}}` with the client subscribed topics as message. When a client disconnects from that endpoint, a similar message will be published as `nrte:subscription_terminate:{{source}}`. It is then possible to subscribe to these special topics and receive the messages. For example:
+```erl
+{nrte_message,<<"nrte:subscription_init:websocket;topic1">>}
+{nrte_message,<<"nrte:subscription_terminate:websocket;topic1">>}
+
+{nrte_message,<<"nrte:subscription_init:eventsource;topic1;topic2;topic3">>}
+{nrte_message,<<"nrte:subscription_terminate:eventsource;topic1;topic2;topic3">>}
+```
+
 ## Support
 
 Any doubt or suggestion? Please, check out [our issue tracker](https://github.com/nomasystems/nrte/issues).

--- a/src/nrte_eventsource.erl
+++ b/src/nrte_eventsource.erl
@@ -27,6 +27,7 @@ init(Req, Opts) ->
     case nrte_auth:authorization(Req, subscribe) of
         {authorized, TopicList} ->
             nrte:subscribe(TopicList),
+            nrte_publications:subscription_init_link_terminate(<<"eventsource">>, TopicList),
             Req2 = cowboy_req:stream_reply(200, #{<<"content-type">> => ?CONTENT_TYPE}, Req),
             {cowboy_loop, Req2, Opts};
         {unauthorized, Req2} ->

--- a/src/nrte_publications.erl
+++ b/src/nrte_publications.erl
@@ -1,0 +1,37 @@
+%%% Copyright 2025 Nomasystems, S.L. http://www.nomasystems.com
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License
+-module(nrte_publications).
+
+%%% EXTERNAL EXPORTS
+-export([subscription_init_link_terminate/2]).
+
+%%% MACROS
+-define(TOPIC_SEPARATOR, <<";">>).
+
+%%%-----------------------------------------------------------------------------
+%%% EXTERNAL EXPORTS
+%%%-----------------------------------------------------------------------------
+-spec subscription_init_link_terminate(binary(), list(binary())) -> ok.
+subscription_init_link_terminate(Source, TopicList) ->
+    Topics = binary:join(TopicList, ?TOPIC_SEPARATOR),
+    nrte:publish(<<"nrte:subscription_init:", Source/binary>>, Topics),
+    Pid = self(),
+    spawn_link(fun() ->
+        process_flag(trap_exit, true),
+        receive
+            {'EXIT', Pid, _} ->
+                nrte:publish(<<"nrte:subscription_terminate:", Source/binary>>, Topics)
+        end
+    end),
+    ok.

--- a/src/nrte_websocket.erl
+++ b/src/nrte_websocket.erl
@@ -24,7 +24,8 @@ init(Req, Opts) ->
     case nrte_auth:authorization(Req, subscribe) of
         {authorized, TopicList} ->
             nrte:subscribe(TopicList),
-            {cowboy_websocket, Req, []};
+            nrte_publications:subscription_init_link_terminate(<<"websocket">>, TopicList),
+            {cowboy_websocket, Req, Opts};
         {unauthorized, Req2} ->
             {stop, Req2, Opts}
     end.


### PR DESCRIPTION
I've also tried using the terminate calls from the cowboy behaviours, but they weren't being called in all contexts, so the current approach seems safer.

Closes #15.